### PR TITLE
linux-linaro_3.14: Fix fetcher failure

### DIFF
--- a/recipes-kernel/linux/linux-linaro_3.14.bb
+++ b/recipes-kernel/linux/linux-linaro_3.14.bb
@@ -11,7 +11,7 @@ S = "${WORKDIR}/git"
 
 PV = "3.14.0"
 
-SRC_URI = "git://git.linaro.org/kernel/linux-linaro-tracking.git;protocol=http;branch=linux-linaro"
+SRC_URI = "git://git.linaro.org/kernel/linux-linaro-tracking.git;protocol=http;nobranch=1"
 SRCREV_pn-${PN} = "3f169e1854aa8b7b555391b661f13349920cfbbb"
 
 SRC_URI += " \


### PR DESCRIPTION
Fix this fetcher failure:

WARNING: Failed to fetch URL git://git.linaro.org/kernel/
linux-linaro-tracking.git;protocol=http;branch=linux-linaro,
attempting MIRRORS if available
ERROR: Fetcher failure: Unable to find revision
3f169e1854aa8b7b555391b661f13349920cfbbb in branch linux-linaro
even from upstream
ERROR: Function failed: Fetcher failure for URL: 'git://git.linaro.org
/kernel/linux-linaro-tracking.git;protocol=http;branch=linux-linaro'.
Unable to fetch URL from any source.
