### PR TITLE
xserver-xf86-config: Add missing colon

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS_prepend = "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
This creates a subtle problem in multi-BSP env like
angstrom where suddenly FILESEXTRAPATHS starts to miss certain paths
as it leaves THISDIR unexpanded

Signed-off-by: Khem Raj raj.khem@gmail.com
